### PR TITLE
docs: README; RSV F protein resistance schema (Nirsevimab / Palivizumab)

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+## plepiseq_json
+
+JSON schemas for the PLepiSeq pipeline.
+
 Python script requires "fastjsonschema", to install just type "pip install fastjsonschema".
 To evaluate json against prepared schema type
 python scheme_validation.py <schema> <your json>, e.g.

--- a/README
+++ b/README
@@ -1,11 +1,24 @@
 ## plepiseq_json
 
-JSON schemas for the PLepiSeq pipeline.
+JSON schemas for the PLepiSeq multiverse of pipelines. This repository stores
+the output schemas for the following components:
+
+- **WGS pipeline** — bacterial and viral whole-genome sequencing analysis
+  (`main_input_schema.json`, `main_output_schema.json`)
+- **Phylogenetic pipeline** — phylogenetic analysis
+  (`main_output_schema_phylogenetics.json`)
+- **External Database downloading pipeline** — schema for database update tracking
+  (`updates_schema.json`)
+
+### Validation
 
 Python script requires "fastjsonschema", to install just type "pip install fastjsonschema".
-To evaluate json against prepared schema type
-python scheme_validation.py <schema> <your json>, e.g.
-# for "bectrial" pipeline output
-python scheme_validation.py main_input_schema.json full_output_1_bacterial.json
-# for "viral" pipeline output
-python scheme_validation.py main_output_schema.json full_output_2_viral.json
+To evaluate json against prepared schema type:
+
+    python scheme_validation.py <schema> <your json>
+
+For example:
+
+
+    # WGS pipeline — viral output
+    python scheme_validation.py main_output_schema.json full_output_2_viral.json

--- a/output_subschemes/rsv_data.json
+++ b/output_subschemes/rsv_data.json
@@ -2,6 +2,17 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Subschema for plepiseq output, RSV specific data",
   "$comment": "Schemat dla outputu, informacje specyficzne dla wirusa RSV",
+  "$defs": {
+    "rsv_mutation_name": {
+      "type": "string",
+      "pattern": "^[A-Z]\\d+[A-Z](\\+[A-Z]\\d+[A-Z])*$",
+      "$comment": "Substytucja aminokwasowa: jedna lub więcej par (aminokwas referencyjny + pozycja + aminokwas w próbce), warianty łączone znakiem '+'. Litery wielkie (jednoliterowe kody AA).",
+      "examples": [
+        "K209R",
+        "N67I+N208Y"
+      ]
+    }
+  },
   "type": "object",
   "properties": {
     "type": {
@@ -59,12 +70,7 @@
               "type": "object",
               "properties": {
                 "mutation_name": {
-                  "type": "string",
-                  "$comment": "Nazwa mutacji (lub kombinacja mutacji oddzielona znakiem '+')",
-                  "examples": [
-                    "K209R",
-                    "N67I+N208Y"
-                  ]
+                  "$ref": "#/$defs/rsv_mutation_name"
                 },
                 "mutation_effect": {
                   "type": "string",
@@ -91,12 +97,7 @@
               "type": "object",
               "properties": {
                 "mutation_name": {
-                  "type": "string",
-                  "$comment": "Nazwa mutacji (lub kombinacja mutacji oddzielona znakiem '+')",
-                  "examples": [
-                    "K209R",
-                    "N67I+N208Y"
-                  ]
+                  "$ref": "#/$defs/rsv_mutation_name"
                 },
                 "mutation_effect": {
                   "type": "string",

--- a/output_subschemes/rsv_data.json
+++ b/output_subschemes/rsv_data.json
@@ -49,7 +49,8 @@
             "type": "string",
             "enum": [
               "Nirsevimab",
-              "Palivizumab"
+              "Palivizumab",
+              "Clesrovimab"
             ],
             "$comment": "Nazwa przeciwciała monoklonalnego. Wymagany."
           },

--- a/output_subschemes/rsv_data.json
+++ b/output_subschemes/rsv_data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Subschema for plepiseq output, RSVspecific data",
-  "$comment": "Schemat dla outputu, informacja specyficzne dla wirusa RSV",
+  "title": "Subschema for plepiseq output, RSV specific data",
+  "$comment": "Schemat dla outputu, informacje specyficzne dla wirusa RSV",
   "type": "object",
   "properties": {
     "type": {
@@ -11,10 +11,145 @@
         "B",
         "unk"
       ],
-      "$comment": "Informacja o typie wirusa grypy zidentyfikowanego w próbce, 'unk' w przypadku problemu z okresleniem podtypu. Wymagany."
+      "$comment": "Informacja o typie wirusa RSV zidentyfikowanego w próbce, 'unk' w przypadku problemu z określeniem podtypu. Wymagany."
+    },
+    "resistance_status": {
+      "type": "string",
+      "enum": [
+        "tak",
+        "nie",
+        "blad"
+      ],
+      "$comment": "Informacja czy moduł Nextflow odpowiedzialny za analizę oporności wykonał się poprawnie. Wymagany."
+    },
+    "resistance_error_message": {
+      "type": "string",
+      "minLength": 1,
+      "$comment": "Dowolny tekst zwracany jako komunikat błędu podczas obliczeń. Wymagany, jeśli resistance_status jest inny niż tak."
+    },
+    "resistance_data": {
+      "type": "array",
+      "minItems": 0,
+      "$comment": "Informacja o występowaniu mutacji w białku F powodujących oporność na przeciwciała monoklonalne stosowane w profilaktyce RSV. Wymagany jeśli resistance_status to tak.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "drug_name": {
+            "type": "string",
+            "enum": [
+              "Nirsevimab",
+              "Palivizumab"
+            ],
+            "$comment": "Nazwa przeciwciała monoklonalnego. Wymagany."
+          },
+          "drug_resistance_status": {
+            "type": "string",
+            "enum": [
+              "resistance",
+              "possible_resistance",
+              "no_impact"
+            ],
+            "$comment": "Ogólny status oporności na dany lek. W przypadku wielu mutacji oporność determinowana jest mutacją o największym efekcie. Wymagany."
+          },
+          "mutation_list_data": {
+            "type": "array",
+            "minItems": 0,
+            "$comment": "Lista mutacji zidentyfikowanych w białku F próbki. Pozycja mutacji jest określona według numeracji w sekwencji białka F z próbki.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mutation_name": {
+                  "type": "string",
+                  "$comment": "Nazwa mutacji (lub kombinacja mutacji oddzielona znakiem '+')",
+                  "examples": [
+                    "K209R",
+                    "N67I+N208Y"
+                  ]
+                },
+                "mutation_effect": {
+                  "type": "string",
+                  "enum": [
+                    "resistance",
+                    "possible_resistance",
+                    "no_impact"
+                  ],
+                  "$comment": "Efekt konkretnej mutacji lub kombinacji mutacji."
+                }
+              },
+              "required": [
+                "mutation_name",
+                "mutation_effect"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "mutation_list_data_reference_numbering": {
+            "type": "array",
+            "minItems": 0,
+            "$comment": "Lista mutacji zidentyfikowanych w białku F próbki w odniesieniu do numeracji referencyjnej sekwencji białka F.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mutation_name": {
+                  "type": "string",
+                  "$comment": "Nazwa mutacji (lub kombinacja mutacji oddzielona znakiem '+')",
+                  "examples": [
+                    "K209R",
+                    "N67I+N208Y"
+                  ]
+                },
+                "mutation_effect": {
+                  "type": "string",
+                  "enum": [
+                    "resistance",
+                    "possible_resistance",
+                    "no_impact"
+                  ],
+                  "$comment": "Efekt konkretnej mutacji lub kombinacji mutacji."
+                }
+              },
+              "required": [
+                "mutation_name",
+                "mutation_effect"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "drug_name",
+          "drug_resistance_status",
+          "mutation_list_data",
+          "mutation_list_data_reference_numbering"
+        ],
+        "additionalProperties": false
+      }
     }
   },
   "required": [
-    "type"
+    "type",
+    "resistance_status"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "resistance_status": {
+            "const": "tak"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "resistance_data"
+        ]
+      },
+      "else": {
+        "required": [
+          "resistance_error_message"
+        ]
+      }
+    }
   ]
 }

--- a/output_subschemes_examples/rsv_data_example_1.json
+++ b/output_subschemes_examples/rsv_data_example_1.json
@@ -1,3 +1,36 @@
 {
-  "type": "A"
+  "type": "A",
+  "resistance_status": "tak",
+  "resistance_data": [
+    {
+      "drug_name": "Nirsevimab",
+      "drug_resistance_status": "resistance",
+      "mutation_list_data": [
+        {
+          "mutation_name": "K209R",
+          "mutation_effect": "possible_resistance"
+        },
+        {
+          "mutation_name": "N67I+N208Y",
+          "mutation_effect": "resistance"
+        }
+      ],
+      "mutation_list_data_reference_numbering": [
+        {
+          "mutation_name": "K212R",
+          "mutation_effect": "possible_resistance"
+        },
+        {
+          "mutation_name": "N70I+N211Y",
+          "mutation_effect": "resistance"
+        }
+      ]
+    },
+    {
+      "drug_name": "Palivizumab",
+      "drug_resistance_status": "no_impact",
+      "mutation_list_data": [],
+      "mutation_list_data_reference_numbering": []
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Expand `README` with PLepiSeq pipeline overview and validation examples
- Extend the RSV output subschema (`output_subschemes/rsv_data.json`) with Nirsevimab/Palivizumab resistance reporting (sample vs reference F protein numbering, mutation effect enums)
- Update `output_subschemes_examples/rsv_data_example_1.json` accordingly

## Notes
- Replaces the previous PR #12, which GitHub closed automatically when the feature branch was renamed to `rsv-resistance-schema`.

## Test plan
- [x] `python3 scheme_validation.py output_subschemes/rsv_data.json output_subschemes_examples/rsv_data_example_1.json`

Made with [Cursor](https://cursor.com)